### PR TITLE
feat: add loading animation

### DIFF
--- a/src/features/Login/ui/LoginForm.tsx
+++ b/src/features/Login/ui/LoginForm.tsx
@@ -63,7 +63,7 @@ export const LoginForm = memo(({ className, onSuccess }: LoginFormProps) => {
   }, [dispatch, getValues, onSuccess]);
 
   if (isLoading) {
-    <LoadingAnimation />;
+    return <LoadingAnimation />;
   }
 
   return (

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import { useNavigate } from 'react-router';
-import { Navigate } from 'react-router-dom';
+import { Link, Navigate } from 'react-router-dom';
 
 import { LoginForm } from '@/features/Login';
 
@@ -15,9 +15,6 @@ export const LoginPage = memo(() => {
   }
   return (
     <main className={cls.loginPage}>
-      <Link to="/main" className={`${cls.link__image}`}>
-        <Logo />
-      </Link>
       <div className={cls.background} />
       <Logo className={cls.logo} left />
       <div className={cls.card}>

--- a/src/shared/ui/loadingAnimation/loadingAnimation.module.scss
+++ b/src/shared/ui/loadingAnimation/loadingAnimation.module.scss
@@ -2,33 +2,29 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100%;
+  height: 450px;
 
-  background-color: $black;
+  background-color: transparent;
 
 }
 
-.leaf{
-  animation: 3s leafRotate linear infinite;
+.leaf {
+  animation: leaf-rotate 3s linear infinite;
 }
 
 .leaf:nth-child(1) {
-  animation: leaf-rotate 3s linear infinite;
-  
+  animation-delay: 0s;
 }
 
 .leaf:nth-child(2) {
-  animation: leaf-rotate 3s linear infinite;
   animation-delay: 0.5s;
 }
 
 .leaf:nth-child(3) {
-  animation: leaf-rotate 3s linear infinite;
   animation-delay: 1s;
 }
 
 .leaf:nth-child(4) {
-  animation: leaf-rotate 3s linear infinite;
   animation-delay: 1.5s;
 }
 

--- a/src/shared/ui/loadingAnimation/loadingAnimation.tsx
+++ b/src/shared/ui/loadingAnimation/loadingAnimation.tsx
@@ -1,13 +1,15 @@
-import cls from './loadingAnimation.module.scss';
+import { Icon } from '../Icon/Icon';
 import Leaf from '@/shared/assets/images/leaf.svg';
+
+import cls from './loadingAnimation.module.scss';
 
 export const LoadingAnimation = () => {
   return (
     <div className={cls.wrapperAnimation}>
-      <Leaf />
-      <Leaf />
-      <Leaf />
-      <Leaf />
+      <Icon Svg={Leaf} className={cls.leaf} />
+      <Icon Svg={Leaf} className={cls.leaf} />
+      <Icon Svg={Leaf} className={cls.leaf} />
+      <Icon Svg={Leaf} className={cls.leaf} />
     </div>
   );
 };


### PR DESCRIPTION
#### Issue

Add loading Animation while request is undone

#### 🤔 This is a ...

- [ ] 🌟 New feature
- [ ] ⚙️ Update feature
- [x] 🔧 Fix feature
- [ ] 🐛 Refactor code
- [ ] 🔗 Fix a broken link
- [ ] ✏️ Fix a typo or grammatical error
- [ ] ❓ Other (specify: **\*\*\*\***\_\_\_\_**\*\*\*\***)

#### Description

- **Brief Overview:** This PR add loading animation while server is thinking

#### Additional Information

- **Screenshots/Links:** 
![image](https://github.com/Suficks/eCommerce/assets/134487538/e694841f-4ebd-4287-8418-888487355623)


#### Checklist

- [x] ✅ I have performed a self-review of my own code.
- [x] 📝 I have commented my code, particularly in hard-to-understand areas.
- [ ] 🔧 I have made corresponding changes to the documentation (if applicable).
- [x] 🚫 My changes generate no new warnings or errors.
